### PR TITLE
Exceed lobby cap

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/controller/LobbyController.java
@@ -115,9 +115,10 @@ public class LobbyController {
         GameType gameType = lobbyPutDTO.getGameType();
 
         lobbyService.updateLobby(lobby, token, name, visibility, gameMode, gameType);
+        lobbyService.checkLobbyCapacity(lobby);
 
         // send messages to client via socket
-        socketMessage.convertAndSend(TOPIC_LOBBY + id, "");
+        socketMessage.convertAndSend(TOPIC_LOBBY + id, DTOMapper.INSTANCE.convertILobbyToLobbyGetDTO(lobby, token));
         socketMessage.convertAndSend(TOPIC_PUBLIC_LOBBIES, "");
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/lobby/Lobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/lobby/Lobby.java
@@ -110,10 +110,6 @@ public class Lobby implements ILobby {
     public void setReady(String token, Boolean ready) throws PlayerNotFoundException {
         IPlayer player = getPlayer(token);
         player.setReady(ready);
-        // Here lobby knows if all players are ready and can inform clients through web socket.
-        // Sum of players that are ready:
-        // long playersReady = playerMap.values().stream().filter(Player::isReady).count();
-        // startGame();
     }
 
     @Override
@@ -129,6 +125,43 @@ public class Lobby implements ILobby {
                 this.host = player;
                 break;
             }
+        }
+    }
+
+    @Override
+    public void reduceLobbyCapacity() {
+        Iterator <IPlayer> it = iterator();
+        while(it.hasNext()){
+            if(it.next() != host && lobbyCapacity < getNumberOfPlayers()){
+                it.remove();
+            }
+        }
+    }
+
+    @Override
+    public void setAllPlayersNotReady(){
+        for (IPlayer player : playerMap.values()){
+            player.setReady(false);
+        }
+    }
+
+    @Override
+    public void balanceTeams(){
+        Team t = null;
+        // we alternate teams between consecutive players
+        for (IPlayer player : playerMap.values()){
+            if (t == null){
+                player.setTeam(Team.values()[0]);
+            }
+            else{
+                if(t == Team.values()[0]){
+                    player.setTeam(Team.values()[1]);
+                }
+                else{
+                    player.setTeam(Team.values()[0]);
+                }
+            }
+            t = player.getTeam();
         }
     }
 
@@ -169,6 +202,11 @@ public class Lobby implements ILobby {
     @Override
     public IPlayer getHost() {
         return host;
+    }
+
+    @Override
+    public int getLobbyCapacity() {
+        return lobbyCapacity;
     }
 
     //TODO: This method does not belong here

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/lobby/interfaces/ILobby.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/lobby/interfaces/ILobby.java
@@ -57,4 +57,12 @@ public interface ILobby extends Iterable<IPlayer>{
     IPlayer generatePlayer();
 
     void addPlayer(IPlayer player) throws FullLobbyException;
+
+    int getLobbyCapacity();
+
+    void reduceLobbyCapacity();
+
+    void setAllPlayersNotReady();
+
+    void balanceTeams();
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/service/LobbyService.java
@@ -191,6 +191,14 @@ public class LobbyService {
         }
     }
 
+    public void checkLobbyCapacity(ILobby lobby) {
+        if(lobby.getLobbyCapacity() < lobby.getNumberOfPlayers()){
+            lobby.reduceLobbyCapacity();
+            lobby.setAllPlayersNotReady();
+            lobby.balanceTeams();
+        }
+    }
+
     public void removePlayerFromLobby(String token, Long lobbyId) {
 
         ILobby lobby = getLobbyByIdElseThrowNotFound(lobbyId);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs22/service/Integration/LobbyServiceIntegrationTests.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs22/service/Integration/LobbyServiceIntegrationTests.java
@@ -1,11 +1,9 @@
 package ch.uzh.ifi.hase.soprafs22.service.Integration;
 
-import ch.uzh.ifi.hase.soprafs22.exceptions.FullLobbyException;
 import ch.uzh.ifi.hase.soprafs22.game.Game;
 import ch.uzh.ifi.hase.soprafs22.game.enums.GameMode;
 import ch.uzh.ifi.hase.soprafs22.game.enums.GameType;
 import ch.uzh.ifi.hase.soprafs22.game.player.IPlayer;
-import ch.uzh.ifi.hase.soprafs22.lobby.Lobby;
 import ch.uzh.ifi.hase.soprafs22.lobby.LobbyManager;
 import ch.uzh.ifi.hase.soprafs22.lobby.enums.Visibility;
 import ch.uzh.ifi.hase.soprafs22.exceptions.SmallestIdNotCreatableException;


### PR DESCRIPTION
Modified update lobby service to remove players if when changing to 1v1 mode the number of players exceeds the capacity.

If players are removed, remaining ones are set to not ready and teams are balanced (it could happen that remaining players are in the same team).